### PR TITLE
Update Fix for BuildConfig.VERSION_NAME

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -100,7 +100,7 @@ android {
             buildConfigField "String", "BASE_URL", "\"https://testaka4.sogei.it/v1/dgc/\""
             buildConfigField "String", "SERVER_HOST", "\"testaka4.sogei.it\""
             buildConfigField "String", "CERTIFICATE_SHA", "\"sha256/R0d+cI8vTcJ3sCbpfQCH0OmdBbulPH3deYhngzOqJVA=\""
-            buildConfigField "String", "versionName", "\"1.1.0\""
+            buildConfigField "String", "versionName", "\"1.1.2\""
             buildConfigField "String", "SDK_VERSION", "\"1.0.0\""
         }
 
@@ -108,7 +108,7 @@ android {
             buildConfigField "String", "BASE_URL", "\"https://get.dgc.gov.it/v1/dgc/\""
             buildConfigField "String", "SERVER_HOST", "\"get.dgc.gov.it\""
             buildConfigField "String", "CERTIFICATE_SHA", "\"sha256/7cZJIDPacG8FS3pq6Mvxg+7yBDM/VYc2alOcbVe/e74=\""
-            buildConfigField "String", "versionName", "\"1.1.0\""
+            buildConfigField "String", "versionName", "\"1.1.2\""
             buildConfigField "String", "SDK_VERSION", "\"1.0.0\""
 
             minifyEnabled false


### PR DESCRIPTION
Keeping 1.1.0 as versionName raises the Force Update Dialog during the checks in FirstActivity.kt .

Aligned to current official release version - 1.1.2