### PR TITLE
Fix: DefaultRealmModule conflict

### DIFF
--- a/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/data/VerifierRepositoryImpl.kt
+++ b/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/data/VerifierRepositoryImpl.kt
@@ -32,11 +32,7 @@ import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.exceptions.RealmPrimaryKeyConstraintException
 import io.realm.kotlin.where
-import it.ministerodellasalute.verificaC19sdk.data.local.AppDatabase
-import it.ministerodellasalute.verificaC19sdk.data.local.Blacklist
-import it.ministerodellasalute.verificaC19sdk.data.local.Key
-import it.ministerodellasalute.verificaC19sdk.data.local.Preferences
-import it.ministerodellasalute.verificaC19sdk.data.local.RevokedPass
+import it.ministerodellasalute.verificaC19sdk.data.local.*
 import it.ministerodellasalute.verificaC19sdk.data.remote.ApiService
 import it.ministerodellasalute.verificaC19sdk.data.remote.model.CertificateRevocationList
 import it.ministerodellasalute.verificaC19sdk.data.remote.model.CrlStatus
@@ -326,9 +322,11 @@ class VerifierRepositoryImpl @Inject constructor(
     }
 
     private fun checkCurrentDownloadSize() {
-        val config =
-            RealmConfiguration.Builder().name(REALM_NAME).allowQueriesOnUiThread(true)
-                .build()
+        val config = RealmConfiguration.Builder()
+            .name(REALM_NAME)
+            .modules(VerificaC19sdkLibraryModule())
+            .allowQueriesOnUiThread(true)
+            .build()
         val realm: Realm = Realm.getInstance(config)
         realm.executeTransaction { transactionRealm ->
             val revokedPasses = transactionRealm.where<RevokedPass>().findAll()
@@ -481,8 +479,11 @@ class VerifierRepositoryImpl @Inject constructor(
 
     private fun insertListToRealm(deltaInsertList: MutableList<String>) {
         try {
-            val config =
-                RealmConfiguration.Builder().name(REALM_NAME).allowWritesOnUiThread(true).build()
+            val config = RealmConfiguration.Builder()
+                .name(REALM_NAME)
+                .modules(VerificaC19sdkLibraryModule())
+                .allowQueriesOnUiThread(true)
+                .build()
             val realm: Realm = Realm.getInstance(config)
             val array = mutableListOf<RevokedPass>()
 
@@ -512,8 +513,11 @@ class VerifierRepositoryImpl @Inject constructor(
 
     private fun deleteAllFromRealm() {
         try {
-            val config =
-                RealmConfiguration.Builder().name(REALM_NAME).allowWritesOnUiThread(true).build()
+            val config = RealmConfiguration.Builder()
+                .name(REALM_NAME)
+                .modules(VerificaC19sdkLibraryModule())
+                .allowQueriesOnUiThread(true)
+                .build()
             val realm: Realm = Realm.getInstance(config)
 
             try {
@@ -535,8 +539,11 @@ class VerifierRepositoryImpl @Inject constructor(
 
     private fun deleteListFromRealm(deltaDeleteList: MutableList<String>) {
         try {
-            val config =
-                RealmConfiguration.Builder().name(REALM_NAME).allowWritesOnUiThread(true).build()
+            val config = RealmConfiguration.Builder()
+                .name(REALM_NAME)
+                .modules(VerificaC19sdkLibraryModule())
+                .allowQueriesOnUiThread(true)
+                .build()
             val realm: Realm = Realm.getInstance(config)
             try {
                 realm.executeTransaction { transactionRealm ->

--- a/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/data/VerifierRepositoryImpl.kt
+++ b/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/data/VerifierRepositoryImpl.kt
@@ -32,7 +32,12 @@ import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.exceptions.RealmPrimaryKeyConstraintException
 import io.realm.kotlin.where
-import it.ministerodellasalute.verificaC19sdk.data.local.*
+import it.ministerodellasalute.verificaC19sdk.data.local.AppDatabase
+import it.ministerodellasalute.verificaC19sdk.data.local.Blacklist
+import it.ministerodellasalute.verificaC19sdk.data.local.Key
+import it.ministerodellasalute.verificaC19sdk.data.local.Preferences
+import it.ministerodellasalute.verificaC19sdk.data.local.RevokedPass
+import it.ministerodellasalute.verificaC19sdk.data.local.VerificaC19sdkRealmModule
 import it.ministerodellasalute.verificaC19sdk.data.remote.ApiService
 import it.ministerodellasalute.verificaC19sdk.data.remote.model.CertificateRevocationList
 import it.ministerodellasalute.verificaC19sdk.data.remote.model.CrlStatus
@@ -323,7 +328,7 @@ class VerifierRepositoryImpl @Inject constructor(
     private fun checkCurrentDownloadSize() {
         val config = RealmConfiguration.Builder()
             .name(REALM_NAME)
-            .modules(VerificaC19sdkLibraryModule())
+            .modules(VerificaC19sdkRealmModule())
             .allowQueriesOnUiThread(true)
             .build()
         val realm: Realm = Realm.getInstance(config)
@@ -480,7 +485,7 @@ class VerifierRepositoryImpl @Inject constructor(
         try {
             val config = RealmConfiguration.Builder()
                 .name(REALM_NAME)
-                .modules(VerificaC19sdkLibraryModule())
+                .modules(VerificaC19sdkRealmModule())
                 .allowQueriesOnUiThread(true)
                 .build()
             val realm: Realm = Realm.getInstance(config)
@@ -514,7 +519,7 @@ class VerifierRepositoryImpl @Inject constructor(
         try {
             val config = RealmConfiguration.Builder()
                 .name(REALM_NAME)
-                .modules(VerificaC19sdkLibraryModule())
+                .modules(VerificaC19sdkRealmModule())
                 .allowQueriesOnUiThread(true)
                 .build()
             val realm: Realm = Realm.getInstance(config)
@@ -540,7 +545,7 @@ class VerifierRepositoryImpl @Inject constructor(
         try {
             val config = RealmConfiguration.Builder()
                 .name(REALM_NAME)
-                .modules(VerificaC19sdkLibraryModule())
+                .modules(VerificaC19sdkRealmModule())
                 .allowQueriesOnUiThread(true)
                 .build()
             val realm: Realm = Realm.getInstance(config)

--- a/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/data/local/RevokedPass.kt
+++ b/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/data/local/RevokedPass.kt
@@ -25,6 +25,10 @@ package it.ministerodellasalute.verificaC19sdk.data.local
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import io.realm.annotations.RealmClass
+import io.realm.annotations.RealmModule
 
 @RealmClass
 open class RevokedPass(@PrimaryKey var hashedUVCI: String = "") : RealmObject()
+
+@RealmModule(library = true, classes = [RevokedPass::class])
+class VerificaC19sdkLibraryModule

--- a/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/data/local/VerificaC19sdkRealmModule.kt
+++ b/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/data/local/VerificaC19sdkRealmModule.kt
@@ -17,14 +17,12 @@
  *  limitations under the License.
  *  ---license-end
  *
- *  Created by danielsp on 9/23/21, 11:50 AM
+ *  Created by RawMain on 12/31/21, 4:19 PM
  */
 
 package it.ministerodellasalute.verificaC19sdk.data.local
 
-import io.realm.RealmObject
-import io.realm.annotations.PrimaryKey
-import io.realm.annotations.RealmClass
+import io.realm.annotations.RealmModule
 
-@RealmClass
-open class RevokedPass(@PrimaryKey var hashedUVCI: String = "") : RealmObject()
+@RealmModule(library = true, classes = [RevokedPass::class])
+class VerificaC19sdkRealmModule

--- a/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/model/VerificationViewModel.kt
+++ b/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/model/VerificationViewModel.kt
@@ -47,10 +47,7 @@ import it.ministerodellasalute.verificaC19sdk.VerificaDownloadInProgressExceptio
 import it.ministerodellasalute.verificaC19sdk.VerificaMinSDKVersionException
 import it.ministerodellasalute.verificaC19sdk.data.VerifierRepository
 import it.ministerodellasalute.verificaC19sdk.data.VerifierRepositoryImpl.Companion.REALM_NAME
-import it.ministerodellasalute.verificaC19sdk.data.local.MedicinalProduct
-import it.ministerodellasalute.verificaC19sdk.data.local.Preferences
-import it.ministerodellasalute.verificaC19sdk.data.local.RevokedPass
-import it.ministerodellasalute.verificaC19sdk.data.local.ScanMode
+import it.ministerodellasalute.verificaC19sdk.data.local.*
 import it.ministerodellasalute.verificaC19sdk.data.remote.model.Rule
 import it.ministerodellasalute.verificaC19sdk.di.DispatcherProvider
 import it.ministerodellasalute.verificaC19sdk.model.*
@@ -611,8 +608,11 @@ class VerificationViewModel @Inject constructor(
             return false
         }
         if (hash != "") {
-            val config =
-                RealmConfiguration.Builder().name(REALM_NAME).allowQueriesOnUiThread(true).build()
+            val config = RealmConfiguration.Builder()
+                .name(REALM_NAME)
+                .modules(VerificaC19sdkLibraryModule())
+                .allowQueriesOnUiThread(true)
+                .build()
             val realm: Realm = Realm.getInstance(config)
             Log.i("Revoke", "Searching")
             val query = realm.where(RevokedPass::class.java)

--- a/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/model/VerificationViewModel.kt
+++ b/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/model/VerificationViewModel.kt
@@ -47,7 +47,11 @@ import it.ministerodellasalute.verificaC19sdk.VerificaDownloadInProgressExceptio
 import it.ministerodellasalute.verificaC19sdk.VerificaMinSDKVersionException
 import it.ministerodellasalute.verificaC19sdk.data.VerifierRepository
 import it.ministerodellasalute.verificaC19sdk.data.VerifierRepositoryImpl.Companion.REALM_NAME
-import it.ministerodellasalute.verificaC19sdk.data.local.*
+import it.ministerodellasalute.verificaC19sdk.data.local.MedicinalProduct
+import it.ministerodellasalute.verificaC19sdk.data.local.Preferences
+import it.ministerodellasalute.verificaC19sdk.data.local.RevokedPass
+import it.ministerodellasalute.verificaC19sdk.data.local.ScanMode
+import it.ministerodellasalute.verificaC19sdk.data.local.VerificaC19sdkRealmModule
 import it.ministerodellasalute.verificaC19sdk.data.remote.model.Rule
 import it.ministerodellasalute.verificaC19sdk.di.DispatcherProvider
 import it.ministerodellasalute.verificaC19sdk.model.*
@@ -610,7 +614,7 @@ class VerificationViewModel @Inject constructor(
         if (hash != "") {
             val config = RealmConfiguration.Builder()
                 .name(REALM_NAME)
-                .modules(VerificaC19sdkLibraryModule())
+                .modules(VerificaC19sdkRealmModule())
                 .allowQueriesOnUiThread(true)
                 .build()
             val realm: Realm = Realm.getInstance(config)


### PR DESCRIPTION
**This commit fixes build issues when DGC-SDK is integrated into an app project, that uses Realm with default settings for other data management.**

-----------------

### **Issue Description :**

Realm's default behavior is indeed to automatically create a RealmModule called DefaultRealmModule which contains all classes extending RealmObject in a project. This module is automatically known by Realm.

Such default behavior is problematic when combining a library project & an app project that both use Realm with default settings.

This is because the DefaultRealmModule will be created for both the library project and the app project, which will cause the project to fail because of duplicate class definition errors.

- Issue References - https://github.com/ministero-salute/it-dgc-verificac19-sdk-android/issues/90

-----------------

### **Fix details :**

It avoids the DefaultRealmModule conflict by setting an explicit library module for DGC-SDK (_VerificaC19sdkLibraryModule_).

This disables the generation of the DefaultRealmModule for the library project and allows the library to be included in the app project that also uses Realm.

- OK build of VerificaC19 whitelabel-app = built-release 1.2.1 using this edited version of DGC-SDK 1.1.1 is available [HERE](https://github.com/VC19bkp/it-dgc-verificac19-sdk-android-BKP/releases/tag/1.1.1-FIX-REALM).

-----------------

