### PR TITLE
fix: check uvci and blacklist before signing certificate

### DIFF
--- a/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/model/VerificationViewModel.kt
+++ b/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/model/VerificationViewModel.kt
@@ -190,13 +190,12 @@ class VerificationViewModel @Inject constructor(
                 greenCertificate = decodeData?.greenCertificate
 
                 certificate = verifierRepository.getCertificate(kid.toBase64())
-
+                certificateIdentifier = extractUVCI(greenCertificate, exemptions?.first())
                 if (certificate == null) {
                     Log.d(TAG, "Verification failed: failed to load certificate")
                     return@withContext
                 }
                 cryptoService.validate(cose, certificate as Certificate, verificationResult)
-                certificateIdentifier = extractUVCI(greenCertificate, exemptions?.first())
                 blackListCheckResult = verifierRepository.checkInBlackList(certificateIdentifier)
             }
 


### PR DESCRIPTION
How to reproduce

1. Try scan this testing certificate (from EU testing DCCs repository) with VerificaC19 for Android

<img width="300px" src="https://user-images.githubusercontent.com/537363/150442326-caeab167-cfa9-4f5c-acc8-a5e1375f0e06.png">

2. Try to scan it using VerificaC19 for iOS

You'll get two different results! Only VerificaC19 for iOS correctly reads certificate's info saying that's not valid cause it's not signed by a trusted DSC. Current PR fixes this behaviour. 